### PR TITLE
Add generic application Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This repository contains documentation and reference configurations for a casino
 - `docs/` – platform documentation
 - `services/example-api/` – simple API in Go with healthcheck
 - `terraform/`, `helm/`, `kustomize/`, `argocd/` – infrastructure and deployment files
+- `helm/app/` – generic Helm chart for deploying applications with ingress and external secrets
 
 ## Getting Started
 

--- a/helm/app/Chart.yaml
+++ b/helm/app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: app
+description: Generic application chart with ingress and external secrets support
+version: 0.1.0
+appVersion: "1.0"
+type: application

--- a/helm/app/README.md
+++ b/helm/app/README.md
@@ -1,0 +1,22 @@
+# Generic Application Chart
+
+This Helm chart deploys a generic application container with optional Nginx ingress and integration with the External Secrets Operator using AWS as the backend.
+
+## Features
+
+- Deployment and Service resources.
+- Optional Ingress resource supporting multiple ingress classes (e.g., `nginx`, `internal-nginx`).
+- Optional ExternalSecret resource to fetch secrets from AWS Secrets Manager via External Secrets Operator.
+
+## Values
+
+Key settings in `values.yaml`:
+
+- `image.repository` – container image to deploy.
+- `ingress.enabled` – enable ingress.
+- `ingress.className` – default ingress class.
+- `ingress.extraClasses` – additional ingress classes to create separate ingress objects.
+- `externalSecrets.enabled` – enable integration with External Secrets Operator.
+- `externalSecrets.secretStoreRef` – reference to a `SecretStore` or `ClusterSecretStore` configured for AWS.
+
+Consult the `values.yaml` file for the full list of configuration options.

--- a/helm/app/templates/_helpers.tpl
+++ b/helm/app/templates/_helpers.tpl
@@ -1,0 +1,17 @@
+{{- define "app.name" -}}
+{{- default .Chart.Name .Values.nameOverride -}}
+{{- end -}}
+
+{{- define "app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "app.name" . -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/app/templates/deployment.yaml
+++ b/helm/app/templates/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+    {{- with .Values.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "app.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          {{- if .Values.externalSecrets.enabled }}
+          envFrom:
+            - secretRef:
+                name: {{ include "app.fullname" . }}-secrets
+          {{- end }}

--- a/helm/app/templates/externalsecret.yaml
+++ b/helm/app/templates/externalsecret.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.externalSecrets.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+spec:
+  refreshInterval: {{ .Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.externalSecrets.secretStoreRef.name }}
+    kind: {{ .Values.externalSecrets.secretStoreRef.kind }}
+  target:
+    name: {{ include "app.fullname" . }}-secrets
+    creationPolicy: Owner
+  data:
+  {{- range .Values.externalSecrets.data }}
+    - secretKey: {{ .secretKey }}
+      remoteRef:
+        key: {{ .key }}
+        {{- if .property }}
+        property: {{ .property }}
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/app/templates/ingress.yaml
+++ b/helm/app/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullName := include "app.fullname" . }}
+{{- $svcPort := .Values.service.port }}
+{{- $classes := append (list .Values.ingress.className) .Values.ingress.extraClasses }}
+{{- range $i, $class := $classes }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}{{- if gt $i 0 }}-{{ $class }}{{- end }}
+  annotations:
+    {{- with $.Values.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ $class }}
+  rules:
+  {{- range $.Values.ingress.hosts }}
+    - host: {{ .host }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+        {{- end }}
+  {{- end }}
+  {{- if $.Values.ingress.tls }}
+  tls:
+  {{- range $.Values.ingress.tls }}
+    - secretName: {{ .secretName }}
+      hosts:
+      {{- range .hosts }}
+        - {{ . }}
+      {{- end }}
+  {{- end }}
+  {{- end }}
+---
+{{- end }}
+{{- end }}

--- a/helm/app/templates/service.yaml
+++ b/helm/app/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "app.fullname" . }}
+  labels:
+    {{- include "app.selectorLabels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "app.selectorLabels" . | nindent 4 }}

--- a/helm/app/values.yaml
+++ b/helm/app/values.yaml
@@ -1,0 +1,30 @@
+replicaCount: 1
+
+image:
+  repository: ""
+  pullPolicy: IfNotPresent
+  tag: ""
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  className: nginx
+  extraClasses: []
+  annotations: {}
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+externalSecrets:
+  enabled: false
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secrets
+    kind: ClusterSecretStore
+  data: []


### PR DESCRIPTION
## Summary
- add a generic application chart under `helm/app`
- support optional ingress with configurable class name(s)
- add External Secrets Operator integration for AWS-backed secrets
- note new chart in root README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c134f9d2c8323b33154d47f37cc91