### PR TITLE
Add modular Terraform stack for VPC and EKS

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,22 @@
+# Terraform Infrastructure Stack
+
+This directory provisions a basic AWS infrastructure stack consisting of:
+
+- **VPC** with three public and three private subnets across available zones
+- **EKS** cluster using two managed node groups:
+  - On-demand instances
+  - Spot instances
+
+The modules are thin wrappers around the official AWS modules and can be used in
+GitOps workflows.
+
+## Usage
+
+```bash
+terraform init
+terraform plan -out plan.tfplan
+terraform apply plan.tfplan
+```
+
+Variables such as the AWS region and cluster name can be overridden via a
+`terraform.tfvars` file or environment variables.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,31 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "vpc" {
+  source = "./modules/vpc"
+  name   = var.name
+  vpc_cidr = var.vpc_cidr
+  tags   = var.tags
+}
+
+module "eks" {
+  source = "./modules/eks"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+  vpc_id          = module.vpc.vpc_id
+  private_subnet_ids = module.vpc.private_subnets
+
+  tags = var.tags
+}

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -1,0 +1,32 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.15.3"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+  cluster_endpoint_public_access = true
+
+  subnet_ids = var.private_subnet_ids
+  vpc_id     = var.vpc_id
+
+  eks_managed_node_groups = {
+    ondemand = {
+      desired_size = var.ondemand_desired_size
+      min_size     = var.ondemand_min_size
+      max_size     = var.ondemand_max_size
+      instance_types = var.ondemand_instance_types
+      capacity_type  = "ON_DEMAND"
+      subnet_ids     = var.private_subnet_ids
+    }
+    spot = {
+      desired_size = var.spot_desired_size
+      min_size     = var.spot_min_size
+      max_size     = var.spot_max_size
+      instance_types = var.spot_instance_types
+      capacity_type  = "SPOT"
+      subnet_ids     = var.private_subnet_ids
+    }
+  }
+
+  tags = var.tags
+}

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -1,0 +1,14 @@
+output "cluster_name" {
+  description = "EKS cluster name"
+  value       = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  description = "EKS cluster endpoint"
+  value       = module.eks.cluster_endpoint
+}
+
+output "node_group_role_arn" {
+  description = "Node group IAM role ARN"
+  value       = module.eks.node_group_iam_role_arns
+}

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -1,0 +1,74 @@
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version for the cluster"
+  type        = string
+  default     = "1.28"
+}
+
+variable "vpc_id" {
+  description = "VPC ID"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs"
+  type        = list(string)
+}
+
+variable "ondemand_instance_types" {
+  description = "Instance types for on-demand node group"
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "ondemand_desired_size" {
+  description = "Desired capacity for on-demand node group"
+  type        = number
+  default     = 2
+}
+
+variable "ondemand_min_size" {
+  description = "Minimum nodes for on-demand node group"
+  type        = number
+  default     = 1
+}
+
+variable "ondemand_max_size" {
+  description = "Maximum nodes for on-demand node group"
+  type        = number
+  default     = 4
+}
+
+variable "spot_instance_types" {
+  description = "Instance types for spot node group"
+  type        = list(string)
+  default     = ["t3.medium"]
+}
+
+variable "spot_desired_size" {
+  description = "Desired capacity for spot node group"
+  type        = number
+  default     = 2
+}
+
+variable "spot_min_size" {
+  description = "Minimum nodes for spot node group"
+  type        = number
+  default     = 1
+}
+
+variable "spot_max_size" {
+  description = "Maximum nodes for spot node group"
+  type        = number
+  default     = 4
+}
+
+variable "tags" {
+  description = "Tags to apply"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/vpc/data.tf
+++ b/terraform/modules/vpc/data.tf
@@ -1,0 +1,1 @@
+data "aws_availability_zones" "available" {}

--- a/terraform/modules/vpc/locals.tf
+++ b/terraform/modules/vpc/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  azs = var.azs != null && length(var.azs) > 0 ? var.azs : slice(data.aws_availability_zones.available.names, 0, 3)
+
+  subnet_prefixes = cidrsubnets(var.vpc_cidr, 8, 6)
+  public_subnets  = [for i in range(3) : local.subnet_prefixes[i]]
+  private_subnets = [for i in range(3,6) : local.subnet_prefixes[i]]
+}

--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -1,0 +1,19 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.1.1"
+
+  name = var.name
+  cidr = var.vpc_cidr
+
+  azs             = local.azs
+  public_subnets  = local.public_subnets
+  private_subnets = local.private_subnets
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = var.tags
+}
+

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnets" {
+  description = "List of public subnet IDs"
+  value       = module.vpc.public_subnets
+}
+
+output "private_subnets" {
+  description = "List of private subnet IDs"
+  value       = module.vpc.private_subnets
+}

--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -1,0 +1,22 @@
+variable "name" {
+  description = "Name prefix for VPC"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "azs" {
+  description = "List of availability zones to use"
+  type        = list(string)
+  default     = null
+}
+
+variable "tags" {
+  description = "Tags to apply to resources"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "vpc_id" {
+  description = "ID of created VPC"
+  value       = module.vpc.vpc_id
+}
+
+output "eks_cluster_name" {
+  description = "Name of the EKS cluster"
+  value       = module.eks.cluster_name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,35 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name" {
+  description = "Base name for resources"
+  type        = string
+  default     = "platform"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+  default     = "platform-eks"
+}
+
+variable "cluster_version" {
+  description = "Kubernetes version"
+  type        = string
+  default     = "1.28"
+}
+
+variable "tags" {
+  description = "Tags to apply"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
## Summary
- implement reusable VPC and EKS modules
- expose root module that provisions the modules
- document Terraform usage

## Testing
- `terraform` command not available


------
https://chatgpt.com/codex/tasks/task_e_687760236404832398fb2378f7aa7642