### PR TITLE
Add Hetzner worker node support

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -6,6 +6,7 @@ This directory provisions a basic AWS infrastructure stack consisting of:
 - **EKS** cluster using two managed node groups:
   - On-demand instances
   - Spot instances
+- Optional worker nodes on Hetzner Cloud using `hcloud`
 
 The modules are thin wrappers around the official AWS modules and can be used in
 GitOps workflows.

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -8,6 +8,11 @@ output "cluster_endpoint" {
   value       = module.eks.cluster_endpoint
 }
 
+output "cluster_certificate_authority_data" {
+  description = "Base64 encoded certificate data"
+  value       = module.eks.cluster_certificate_authority_data
+}
+
 output "node_group_role_arn" {
   description = "Node group IAM role ARN"
   value       = module.eks.node_group_iam_role_arns

--- a/terraform/modules/hetzner-nodes/README.md
+++ b/terraform/modules/hetzner-nodes/README.md
@@ -1,0 +1,26 @@
+# Hetzner Node Module
+
+This module provisions additional Kubernetes worker nodes on Hetzner Cloud. It
+can be used to extend an existing Amazon EKS cluster with nodes running outside
+of AWS. Nodes are created using the `hcloud` provider and bootstrapped via
+cloud-init.
+
+The default user data installs Docker, kubeadm and joins the EKS cluster using
+the provided token and certificate hash. You can supply custom user data if
+different provisioning is required (for example, installing EKS Anywhere).
+
+## Variables
+
+- `name_prefix` – Prefix for server names.
+- `node_count` – Number of servers to create.
+- `server_type` – Hetzner server type (e.g. `cx31`).
+- `image` – OS image to use (default `ubuntu-22.04`).
+- `location` – Hetzner location (e.g. `fsn1`).
+- `ssh_keys` – List of SSH key IDs to inject.
+- `user_data` – Cloud-init script for node bootstrap.
+- `labels` – Labels to apply to servers.
+
+## Outputs
+
+- `node_names` – Names of created servers.
+- `node_ips` – Public IPv4 addresses of the nodes.

--- a/terraform/modules/hetzner-nodes/main.tf
+++ b/terraform/modules/hetzner-nodes/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    hcloud = {
+      source  = "hetznercloud/hcloud"
+      version = ">= 1.39.0"
+    }
+  }
+}
+
+resource "hcloud_server" "node" {
+  count       = var.node_count
+  name        = "${var.name_prefix}-${count.index}"
+  server_type = var.server_type
+  image       = var.image
+  location    = var.location
+  ssh_keys    = var.ssh_keys
+  user_data   = var.user_data
+  labels      = var.labels
+}
+
+output "node_ips" {
+  description = "Public IPv4 addresses of Hetzner nodes"
+  value       = [for s in hcloud_server.node : s.ipv4_address]
+}

--- a/terraform/modules/hetzner-nodes/outputs.tf
+++ b/terraform/modules/hetzner-nodes/outputs.tf
@@ -1,0 +1,9 @@
+output "node_names" {
+  description = "Names of the created Hetzner servers"
+  value       = [for s in hcloud_server.node : s.name]
+}
+
+output "node_ips" {
+  description = "Public IPv4 addresses"
+  value       = [for s in hcloud_server.node : s.ipv4_address]
+}

--- a/terraform/modules/hetzner-nodes/variables.tf
+++ b/terraform/modules/hetzner-nodes/variables.tf
@@ -1,0 +1,46 @@
+variable "name_prefix" {
+  description = "Prefix for Hetzner server names"
+  type        = string
+}
+
+variable "node_count" {
+  description = "Number of nodes to create"
+  type        = number
+  default     = 1
+}
+
+variable "server_type" {
+  description = "Hetzner server type"
+  type        = string
+  default     = "cx31"
+}
+
+variable "image" {
+  description = "OS image to use"
+  type        = string
+  default     = "ubuntu-22.04"
+}
+
+variable "location" {
+  description = "Hetzner location"
+  type        = string
+  default     = "fsn1"
+}
+
+variable "ssh_keys" {
+  description = "SSH key IDs allowed to access the server"
+  type        = list(string)
+  default     = []
+}
+
+variable "user_data" {
+  description = "Cloud-init user data for node bootstrap"
+  type        = string
+  default     = ""
+}
+
+variable "labels" {
+  description = "Labels to apply to servers"
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,3 +7,19 @@ output "eks_cluster_name" {
   description = "Name of the EKS cluster"
   value       = module.eks.cluster_name
 }
+
+output "eks_cluster_endpoint" {
+  description = "EKS cluster API endpoint"
+  value       = module.eks.cluster_endpoint
+}
+
+output "eks_cluster_ca" {
+  description = "Certificate authority data for the cluster"
+  value       = module.eks.cluster_certificate_authority_data
+}
+
+output "hetzner_node_ips" {
+  description = "Public IP addresses of Hetzner nodes"
+  value       = try(module.hetzner_nodes[0].node_ips, [])
+  depends_on  = [module.hetzner_nodes]
+}

--- a/terraform/user_data/hetzner-kubeadm.sh
+++ b/terraform/user_data/hetzner-kubeadm.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+apt-get update -y
+apt-get install -y apt-transport-https ca-certificates curl gnupg lsb-release
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
+add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+apt-get update -y
+apt-get install -y docker-ce
+systemctl enable --now docker
+
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+apt-add-repository "deb http://apt.kubernetes.io/ kubernetes-xenial main"
+apt-get update -y
+apt-get install -y kubelet kubeadm kubectl
+
+kubeadm join ${cluster_endpoint} \
+  --token ${bootstrap_token} \
+  --discovery-token-ca-cert-hash ${ca_cert_hash}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,3 +33,65 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "enable_hetzner_nodes" {
+  description = "Whether to provision worker nodes on Hetzner"
+  type        = bool
+  default     = false
+}
+
+variable "hetzner_token" {
+  description = "API token for Hetzner Cloud"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "hetzner_node_count" {
+  description = "Number of Hetzner nodes to create"
+  type        = number
+  default     = 1
+}
+
+variable "hetzner_server_type" {
+  description = "Hetzner server type"
+  type        = string
+  default     = "cx31"
+}
+
+variable "hetzner_image" {
+  description = "Operating system image"
+  type        = string
+  default     = "ubuntu-22.04"
+}
+
+variable "hetzner_location" {
+  description = "Hetzner location"
+  type        = string
+  default     = "fsn1"
+}
+
+variable "hetzner_ssh_keys" {
+  description = "List of SSH key IDs to add to servers"
+  type        = list(string)
+  default     = []
+}
+
+variable "hetzner_user_data" {
+  description = "Optional custom user data for Hetzner nodes"
+  type        = string
+  default     = ""
+}
+
+variable "hetzner_bootstrap_token" {
+  description = "kubeadm token for joining nodes"
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "hetzner_ca_cert_hash" {
+  description = "CA cert hash for kubeadm join"
+  type        = string
+  default     = ""
+}

--- a/terragrunt/terragrunt.hcl
+++ b/terragrunt/terragrunt.hcl
@@ -1,0 +1,15 @@
+terraform {
+  source = "../terraform"
+}
+
+inputs = {
+  region                 = "us-east-1"
+  name                   = "platform"
+  cluster_name           = "platform-eks"
+  enable_hetzner_nodes   = true
+  hetzner_token          = get_env("HCLOUD_TOKEN", "")
+  hetzner_node_count     = 2
+  hetzner_server_type    = "cx31"
+  hetzner_image          = "ubuntu-22.04"
+  hetzner_location       = "fsn1"
+}


### PR DESCRIPTION
## Summary
- add `hetzner-nodes` module for provisioning external workers
- extend root terraform to optionally create Hetzner nodes
- expose new variables and outputs for cluster details and node IPs
- update EKS module outputs with certificate authority data
- provide sample kubeadm user-data script
- add terragrunt configuration example

## Testing
- `terraform init -backend=false` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776e14276483238172306bd2b4c215