### PR TITLE
Add Docker image vulnerability scanning

### DIFF
--- a/.github/workflows/well-architected.yml
+++ b/.github/workflows/well-architected.yml
@@ -17,3 +17,17 @@ jobs:
           config_file: .checkov.yaml
           quiet: true
           framework: terraform
+
+  image-scan:
+    runs-on: ubuntu-latest
+    needs: checkov
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build example-api image
+        run: docker build -t example-api ./services/example-api
+      - name: Scan Docker image
+        uses: aquasecurity/trivy-action@v0.12.0
+        with:
+          image-ref: example-api:latest
+          severity: CRITICAL,HIGH
+          exit-code: '1'

--- a/README.md
+++ b/README.md
@@ -56,4 +56,5 @@ See `docs/02-terragrunt-strategy.md` for the Terragrunt proposal.
 ## Compliance Checks
 
 A GitHub Actions workflow (`well-architected.yml`) runs [Checkov](https://github.com/bridgecrewio/checkov) against the Terraform code. Custom policies located in the `checkov-policies/` directory map to AWS Well-Architected Framework best practices.
+It also builds the `services/example-api` Docker image and scans it with [Trivy](https://github.com/aquasecurity/trivy). The workflow fails if any HIGH or CRITICAL vulnerabilities are found.
 


### PR DESCRIPTION
## Summary
- extend the well-architected workflow to scan built Docker images
- document the new Trivy scanning step in the README

## Testing
- `pip install yamllint` *(fails: Tunnel connection failed)*
- `apt-get update` *(fails: repository InRelease is not signed)*


------
https://chatgpt.com/codex/tasks/task_e_688733e34e90832389d950acd86eed44