### PR TITLE
Add default network policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This repository contains documentation and reference configurations for a casino
 - `terraform/`, `helm/`, `kustomize/`, `argocd/` – infrastructure and deployment files
 - `terragrunt/` – Terragrunt configuration linking Terraform modules
 - `helm/app/` – generic Helm chart for deploying applications with ingress and external secrets
+- `network-policies/` - baseline Kubernetes NetworkPolicy manifests
 - `argocd/applicationset.yaml` – example ApplicationSet manifest for ArgoCD
 
 ## Getting Started

--- a/network-policies/README.md
+++ b/network-policies/README.md
@@ -1,0 +1,46 @@
+# Kubernetes Network Policies
+
+This directory contains baseline `NetworkPolicy` manifests.
+
+- `default-deny-all.yaml` &ndash; denies all ingress and egress within a namespace.
+- `allow-from-same-namespace.yaml` &ndash; permits traffic between pods in the same namespace.
+- `allow-dns-egress.yaml` &ndash; allows egress to the `kube-system` DNS service.
+
+Apply the default deny policy first, then layer on namespace‑specific rules.
+
+## Applying with kubectl
+
+```bash
+# Apply policies to a namespace
+kubectl apply -n <namespace> -f network-policies/default-deny-all.yaml
+kubectl apply -n <namespace> -f network-policies/allow-from-same-namespace.yaml
+kubectl apply -n <namespace> -f network-policies/allow-dns-egress.yaml
+```
+
+## Deploying via ArgoCD
+
+Create an ArgoCD `Application` that points to this directory or include the path
+in your existing `ApplicationSet`.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: network-policies
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: <repository-url>
+    targetRevision: HEAD
+    path: network-policies
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: network-policies
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+```
+
+This ensures the network policies are synchronized across clusters by ArgoCD.

--- a/network-policies/allow-dns-egress.yaml
+++ b/network-policies/allow-dns-egress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/network-policies/allow-from-same-namespace.yaml
+++ b/network-policies/allow-from-same-namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-same-namespace
+spec:
+  podSelector: {}
+  ingress:
+  - from:
+    - podSelector: {}
+  policyTypes:
+  - Ingress

--- a/network-policies/default-deny-all.yaml
+++ b/network-policies/default-deny-all.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
## Summary
- add baseline network policies
- document application via kubectl or ArgoCD
- reference network-policies directory in the repo README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688733e21f3c83239a92ff00f7b500a4